### PR TITLE
Enable ESM compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,14 @@
-module.exports = {
-  preset: 'ts-jest',
+export default {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
   globals: {
     'ts-jest': {
+      useESM: true,
       tsconfig: 'tsconfig.json',
     },
   },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^\.\/index.js$': '<rootDir>/src/index.ts',
+  },
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "my-graphql-apollo",
   "version": "1.0.0",
+  "type": "module",
   "description": "GraphQL server built with Apollo Server, Node.js, and TypeScript. It serves as a mock API for managing TV shows data",
   "main": "index.js",
   "scripts": {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-tag';
 import { GraphQLClient } from 'graphql-request';
-import { startServer, stopServer } from './index';
+import { startServer, stopServer } from './index.js';
 
 // 📝 Define GraphQL queries
 const GET_TV_SHOWS = gql`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ES2018" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -25,7 +25,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "NodeNext" /* Emit native ECMAScript modules for Node.js. */,
+    "moduleResolution": "NodeNext",
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
## Summary
- support ESM modules in Jest by switching to the `default-esm` preset
- mark the package as a module
- compile TypeScript for NodeNext ESM
- update test imports for ESM

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686418d594bc83238200518223dc4e74